### PR TITLE
Use in-toto statement v1 without `?draft`

### DIFF
--- a/triggered-build/v1/example.json
+++ b/triggered-build/v1/example.json
@@ -1,5 +1,5 @@
 {
-    "_type": "https://in-toto.io/Statement/v1?draft",
+    "_type": "https://in-toto.io/Statement/v1",
     "predicateType": "https://slsa.dev/provenance/v1?draft",
     "predicate": {
         "buildDefinition": {


### PR DESCRIPTION
Statement v1 has been released, so we can drop `?draft`.
