### PR TITLE
deprecate in favor of official GCB build type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Community-maintained SLSA buildTypes for Google Cloud Build
 
 **This build type is now deprecated.** For the current SLSA Provenance for
-Cloud Build, see [Build Type: Cloud Build v1 build][gcb-build-type]
-in the Google Cloud documentation.
+Cloud Build, see
+https://docs.cloud.google.com/build/gcb-buildtypes/google-worker/v1.
 
 This repo contains community-maintained
 [SLSA Provenance](https://slsa.dev/provenance/v1) `buildType` definitions for

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Community-maintained SLSA buildTypes for Google Cloud Build
 
+**This build type is now deprecated.** For the current SLSA Provenance for
+Cloud Build, see [Build Type: Cloud Build v1 build][gcb-build-type]
+in the Google Cloud documentation.
+
 This repo contains community-maintained
 [SLSA Provenance](https://slsa.dev/provenance/v1) `buildType` definitions for
 Google Cloud Build (GCB).

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ definitions, served under a URL it controls, once it officially supports SLSA.
 In the meantime, this unofficial definition can be used by tooling that runs on
 top of GCB to describe a Google Cloud build.
 
-Note: This build type is now deprecated. For the current SLSA Provenance for
-Cloud Build, see [Build Type: Cloud Build v1 build][gcb-build-type]
-in the Google Cloud documentation.
-
-[gcb-build-type][https://docs.cloud.google.com/build/gcb-buildtypes/google-worker/v1]
-
 ## What's in this repo
 
 -   [docs/](docs/): GitHub Pages configuration for

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ definitions, served under a URL it controls, once it officially supports SLSA.
 In the meantime, this unofficial definition can be used by tooling that runs on
 top of GCB to describe a Google Cloud build.
 
+Note: This build type is now deprecated. For the current SLSA Provenance for
+Cloud Build, see [Build Type: Cloud Build v1 build][gcb-build-type]
+in the Google Cloud documentation.
+
+[gcb-build-type][https://docs.cloud.google.com/build/gcb-buildtypes/google-worker/v1]
+
 ## What's in this repo
 
 -   [docs/](docs/): GitHub Pages configuration for

--- a/triggered-build/v1/README.md
+++ b/triggered-build/v1/README.md
@@ -1,5 +1,11 @@
 # Build Type: GCB Triggered Build
 
+**This build type is now deprecated.** For the current SLSA Provenance for
+Cloud Build, see [Build Type: Cloud Build v1 build][gcb-build-type]
+in the Google Cloud documentation.
+
+[gcb-build-type][https://docs.cloud.google.com/build/gcb-buildtypes/google-worker/v1]
+
 This is a community-maintained [SLSA Provenance](https://slsa.dev/provenance/v1)
 `buildType` that describes the execution a build by Google Cloud Build reading
 the build configuration from source.

--- a/triggered-build/v1/README.md
+++ b/triggered-build/v1/README.md
@@ -10,12 +10,6 @@ served under a URL it controls, once it officially supports SLSA. In the
 meantime, this unofficial definition can be used by tooling that runs on top of
 GCB to describe a Google Cloud Build.
 
-Note: This build type is now deprecated. For the current SLSA Provenance for
-Cloud Build, see [Build Type: Cloud Build v1 build][gcb-build-type]
-in the Google Cloud documentation.
-
-[gcb-build-type][https://docs.cloud.google.com/build/gcb-buildtypes/google-worker/v1]
-
 ## Description
 
 ```jsonc

--- a/triggered-build/v1/README.md
+++ b/triggered-build/v1/README.md
@@ -1,10 +1,8 @@
 # Build Type: GCB Triggered Build
 
 **This build type is now deprecated.** For the current SLSA Provenance for
-Cloud Build, see [Build Type: Cloud Build v1 build][gcb-build-type]
-in the Google Cloud documentation.
-
-[gcb-build-type][https://docs.cloud.google.com/build/gcb-buildtypes/google-worker/v1]
+Cloud Build, see
+https://docs.cloud.google.com/build/gcb-buildtypes/google-worker/v1.
 
 This is a community-maintained [SLSA Provenance](https://slsa.dev/provenance/v1)
 `buildType` that describes the execution a build by Google Cloud Build reading

--- a/triggered-build/v1/README.md
+++ b/triggered-build/v1/README.md
@@ -10,6 +10,12 @@ served under a URL it controls, once it officially supports SLSA. In the
 meantime, this unofficial definition can be used by tooling that runs on top of
 GCB to describe a Google Cloud Build.
 
+Note: This build type is now deprecated. For the current SLSA Provenance for
+Cloud Build, see [Build Type: Cloud Build v1 build][gcb-build-type]
+in the Google Cloud documentation.
+
+[gcb-build-type][https://docs.cloud.google.com/build/gcb-buildtypes/google-worker/v1]
+
 ## Description
 
 ```jsonc

--- a/triggered-build/v1/example.json
+++ b/triggered-build/v1/example.json
@@ -3,12 +3,15 @@
     "predicateType": "https://slsa.dev/provenance/v1",
     "predicate": {
         "buildDefinition": {
-            "buildType": "https://cloud.google.com/build/gcb-buildtypes/google-worker/v1",
+            "buildType": "https://slsa-framework.github.io/gcb-buildtypes/triggered-build/v1",
             "externalParameters": {
-                "buildConfigSource": {
+                "configSource": {
                     "ref": "refs/heads/main",
                     "repository": "https://github.com/GoogleCloudPlatform/cloud-build-samples",
                     "path": "basic-config/cloudbuild.yaml"
+                },
+                "sourceToBuild": {
+                    "dir": "basic-config"
                 },
                 "substitutions": {
                     "count": "3",
@@ -24,9 +27,6 @@
             ]
         },
         "runDetails": {
-            "builder": {
-                "id": "https://cloudbuild.googleapis.com/GoogleHostedWorker"
-            },
             "metadata": {
                 "invocationId": "https://cloudbuild.googleapis.com/v1/projects/cloud-build-samples-project/locations/us-west1/builds/03eb98be-0390-4b05-b861-ef52ed4d2a34",
                 "startedOn": "2023-01-01T12:34:56Z"

--- a/triggered-build/v1/example.json
+++ b/triggered-build/v1/example.json
@@ -3,15 +3,12 @@
     "predicateType": "https://slsa.dev/provenance/v1",
     "predicate": {
         "buildDefinition": {
-            "buildType": "https://slsa-framework.github.io/gcb-buildtypes/triggered-build/v1",
+            "buildType": "https://cloud.google.com/build/gcb-buildtypes/google-worker/v1",
             "externalParameters": {
-                "configSource": {
+                "buildConfigSource": {
                     "ref": "refs/heads/main",
                     "repository": "https://github.com/GoogleCloudPlatform/cloud-build-samples",
                     "path": "basic-config/cloudbuild.yaml"
-                },
-                "sourceToBuild": {
-                    "dir": "basic-config"
                 },
                 "substitutions": {
                     "count": "3",
@@ -27,6 +24,9 @@
             ]
         },
         "runDetails": {
+            "builder": {
+                "id": "https://cloudbuild.googleapis.com/GoogleHostedWorker"
+            },
             "metadata": {
                 "invocationId": "https://cloudbuild.googleapis.com/v1/projects/cloud-build-samples-project/locations/us-west1/builds/03eb98be-0390-4b05-b861-ef52ed4d2a34",
                 "startedOn": "2023-01-01T12:34:56Z"


### PR DESCRIPTION
Add notes to readme files that the listed build is currently deprecated and to view google cloud documentation for the current SLSA Provenance for Cloud Build.

Context: GCB now produces https://cloud.google.com/build/gcb-buildtypes/google-worker/v1.